### PR TITLE
Add missing imports for etree and urllib2

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -23,6 +23,8 @@ IDs not used
 import os            # path.abspath, join, dirname
 import re            #
 import inspect       # getfile, currentframe
+import urllib2
+from lxml import etree
 from io import open  #
 
 ### Return dict value if all fields exists "" otherwise (to allow .isdigit()), avoid key errors


### PR DESCRIPTION
I was getting the error `etree is not defined`, and after fixing that import, `urllib2` was also missing.  This PR adds those missing imports.

```
INFO (__init__:459) - Library: /config/Library/Application Support/Plex Media Server
2018-08-07 18:49:14,065 (7f14d5412700) :  INFO (__init__:461) - 'X-Plex-Token.id' file present
2018-08-07 18:49:14,065 (7f14d5412700) :  INFO (__init__:470) - Place correct Plex token in X-Plex-Token.id file in logs folder or in PLEX_LIBRARY_URL variable to have a log per library - https://support.plex.tv/hc/en-us/articles/204059436-Finding-your-account-token-X-Plex-Tokenname 'etree' is not defined
2018-08-07 18:49:14,066 (7f14d5412700) :  INFO (core:611) - Started plug-in
```
