### PR TITLE
Fix URL Encoded path being passed during search

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -110,6 +110,7 @@ def Search(results, media, lang, manual, movie):
   YOUTUBE_API_KEY   = Prefs['YouTube-Agent_youtube_api_key']
   displayname = os.path.basename(media.items[0].parts[0].file) if movie else media.show
   filename = os.path.basename(media.items[0].parts[0].file) if movie else os.path.splitext(os.path.basename(media.filename))[0]
+  filename = urllib2.unquote(filename)
   dir      = GetMediaDir(media, movie)
   Log(''.ljust(157, '='))
   Log('search() - dir: {}, filename: {}'.format(dir, filename))


### PR DESCRIPTION
At some point the filename was being URL escaped which caused the regex looking for an ID to fail. This was causing some super weird behavior, such as episode titles having the first "a" in them replaced with a space, and all other metadata failing to be found. Adding this one line fixes that entirely, though it may cause hiccups if a file for whatever reason HAS url escaped characters in the name on purpose.