### PR TITLE
Added new functionality to read metadata for episodes and movies from…

### DIFF
--- a/Contents/DefaultPrefs.json
+++ b/Contents/DefaultPrefs.json
@@ -1,5 +1,6 @@
 [
   { "id":"add_user_as_director",          "label":"Set YouTube usernames as director in metadata",  "type":"bool", "default":"false"                                     },
   { "id":"media_poster_source",           "label":"Media Poster",                                   "type":"enum", "default":"Channel", "values": ["Channel", "Episode"] },
-  { "id":"YouTube-Agent_youtube_api_key", "label":"YouTube API Key (Leave blank for Default Key)",  "type":"text", "default":"AIzaSyC2q8yjciNdlYRNdvwbb7NEcDxBkv1Cass"   }
+  { "id":"YouTube-Agent_youtube_api_key", "label":"YouTube API Key (Leave blank for Default Key)",  "type":"text", "default":"AIzaSyC2q8yjciNdlYRNdvwbb7NEcDxBkv1Cass"   },
+  { "id":"metadata_source",               "label":"Metadata Source",                                "type":"enum", "default":"JsonWithApiBackup", "values": ["JsonWithApiBackup", "ApiOnly"]}
 ]


### PR DESCRIPTION
… info.json files.

Fixes #40 

I hope this method of handling this is okay with you. I split up the search method into two methods that search via api and via info.json file. I also broke out parts of the update method into methods that can search via api and via info.json.

I added a setting so that users can choose if they only want to use the API, or if they would like to use the info.json file with the api as a backup only. I have tested using both methods on a TV Series library and it performed as expected.

There was one limitation that I came across that may be of interest. The thumbnails that are returned from the youtube api can be accessed using "standard" "high" and other keywords. The json file simply gives them a numeric index. In my experience the higher index values had higher resolution so I am attempting to pull that first and then moving down the list if that doesn't exist. we could also read all values into a collection and specifically grab thumbnails with a higher resolution.

I am not a python developer by trade. C# is my bread and butter. I tried to follow python conventions to the best of my knowledge, but if I did anything strange or unconventional, feel free to change it.

I also will not have any issues with any critiques or feedback if there's something you'd like me to change, but this should provide a pretty good starting point.