### PR TITLE
Fix channel banner resolution

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -357,8 +357,8 @@ def Update(metadata, media, lang, force, movie):
                 Log.Info('[ ] role:        {}'.format(Dict(json_channel_details,'snippet','title')))
                 
                 thumb = Dict(json_channel_details, 'brandingSettings', 'image', 'bannerTvLowImageUrl' ) or Dict(json_channel_details, 'brandingSettings', 'image', 'bannerTvMediumImageUrl') \
-                  or Dict(json_channel_details, 'brandingSettings', 'image', 'bannerTvHighImageUrl') or Dict(json_channel_details, 'brandingSettings', 'image', 'bannerTvImageUrl'      ) \
-                  or Dict(json_channel_details, 'brandingSettings', 'image', 'bannerExternalUrl')
+                  or Dict(json_channel_details, 'brandingSettings', 'image', 'bannerTvHighImageUrl') or Dict(json_channel_details, 'brandingSettings', 'image', 'bannerTvImageUrl'      )
+                if not thumb: thumb = '{}=s1920'.format(Dict(json_channel_details, 'brandingSettings', 'image', 'bannerExternalUrl'))
                 if thumb and thumb not in metadata.art:      Log('[X] art:       {}'.format(thumb));  metadata.art [thumb] = Proxy.Media(HTTP.Request(thumb).content, sort_order=1)
                 else:                                        Log('[ ] art:       {}'.format(thumb))
                 if thumb and thumb not in metadata.banners:  Log('[X] banners:   {}'.format(thumb));  metadata.banners [thumb] = Proxy.Media(HTTP.Request(thumb).content, sort_order=1)
@@ -372,8 +372,8 @@ def Update(metadata, media, lang, force, movie):
         ### Cast comes from channel
         else:    
           thumb         = Dict(json_channel_details, 'brandingSettings', 'image', 'bannerTvLowImageUrl' ) or Dict(json_channel_details, 'brandingSettings', 'image', 'bannerTvMediumImageUrl') \
-                       or Dict(json_channel_details, 'brandingSettings', 'image', 'bannerTvHighImageUrl') or Dict(json_channel_details, 'brandingSettings', 'image', 'bannerTvImageUrl'      ) \
-                       or Dict(json_channel_details, 'brandingSettings', 'image', 'bannerExternalUrl')
+                       or Dict(json_channel_details, 'brandingSettings', 'image', 'bannerTvHighImageUrl') or Dict(json_channel_details, 'brandingSettings', 'image', 'bannerTvImageUrl'      )
+          if not thumb: thumb = '{}=s1920'.format(Dict(json_channel_details, 'brandingSettings', 'image', 'bannerExternalUrl'))
           if thumb and thumb not in metadata.art:      Log(u'[X] art:       {}'.format(thumb));  metadata.art [thumb] = Proxy.Media(HTTP.Request(thumb).content, sort_order=1)
           else:                                        Log(u'[ ] art:       {}'.format(thumb))
           if thumb and thumb not in metadata.banners:  Log(u'[X] banners:   {}'.format(thumb));  metadata.banners [thumb] = Proxy.Media(HTTP.Request(thumb).content, sort_order=1)


### PR DESCRIPTION
Hi @ZeroQI, it's been a while!

Recently I've been bothered by the fact that channel banners are relatively low resolution. I figured there had to be a way to get a higher resolution, but when I performed the channel API request, I only ever got the `bannerExternalUrl` property, which returned a URL to a low-resolution banner.

I actually added the code that loads from `bannerExternalUrl` in ab625de24eda83ee41e07407b78f7f0a0d397629, because I discovered none of the other properties were ever returned by the API. At the time I didn't understand why, but after reading the Google documentation, I see that all of those other properties have been deprecated in favor of `bannerExternalUrl`.

https://developers.google.com/youtube/v3/docs/channels

But that still didn't explain why it was low resolution. I finally discovered that the plain URL returns a default image, but you have to pass a parameter at the end of the image URL to get a larger size. Fortunately, banners are 16:9, so if we want a banner that looks good on most computers and TVs, we can request it with a width of 1920. (We could go higher like 2560, but that might be overkill.)

Here is an example:

**API**
https://www.googleapis.com/youtube/v3/channels?part=snippet,contentDetails,statistics,brandingSettings&id=UC6k_GngLDtxbkUlZOq6_h5g&key=KEY

**Default URL returned by `bannerExternalUrl`**
https://yt3.ggpht.com/qzmslBWODtyXaPz1UZCW0v1qrBw0K0ME-AucIQKbgYTAjm0OfqyNcQ12dx14gQCPJQNfIkv1mw

**With `=s1920` appended**
https://yt3.ggpht.com/qzmslBWODtyXaPz1UZCW0v1qrBw0K0ME-AucIQKbgYTAjm0OfqyNcQ12dx14gQCPJQNfIkv1mw=s1920

Anyway, I'm happy to contribute this change if you're interested.