### PR TITLE
Fix video thumbnail aspect ratio

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -231,7 +231,7 @@ def Update(metadata, media, lang, force, movie):
       thumb                            = json_video_details['snippet']['thumbnails']['default']['url'];                               Log(u'thumb: "{}"'.format(thumb))
       if thumb and thumb not in metadata.posters:
         Log(u'poster: "{}"'.format(thumb))
-        metadata.posters[thumb]        = Proxy.Media(HTTP.Request(Dict(json_video_details, 'snippet', 'thumbnails', 'default', 'url') or Dict(json_video_details, 'snippet', 'thumbnails', 'high', 'url') or Dict(json_video_details, 'snippet', 'thumbnails', 'standard', 'url')).content, sort_order=1)
+        metadata.posters[thumb]        = Proxy.Media(HTTP.Request(Dict(json_video_details, 'snippet', 'thumbnails', 'maxres', 'url') or Dict(json_video_details, 'snippet', 'thumbnails', 'medium', 'url') or Dict(json_video_details, 'snippet', 'thumbnails', 'standard', 'url') or Dict(json_video_details, 'snippet', 'thumbnails', 'high', 'url') or Dict(json_video_details, 'snippet', 'thumbnails', 'default', 'url')).content, sort_order=1)
       if Dict(json_video_details, 'statistics', 'likeCount') and int(json_video_details['statistics']['likeCount']) > 0:
         metadata.rating                = float(10*int(json_video_details['statistics']['likeCount'])/(int(json_video_details['statistics']['dislikeCount'])+int(json_video_details['statistics']['likeCount'])));  Log('rating: {}'.format(metadata.rating))
       if Prefs['add_user_as_director']:
@@ -424,7 +424,7 @@ def Update(metadata, media, lang, force, movie):
             episode.title                   = sanitize_path(Dict(video, 'snippet', 'title'       ));             Log.Info(u'[ ] title:        {}'.format(Dict(video, 'snippet', 'title'       )))
             episode.summary                 = sanitize_path(Dict(video, 'snippet', 'description' ));             Log.Info(u'[ ] description:  {}'.format(Dict(video, 'snippet', 'description' ).replace('\n', '. ')))
             episode.originally_available_at = Datetime.ParseDate(Dict(video, 'contentDetails', 'videoPublishedAt')).date();  Log.Info('[ ] publishedAt:  {}'.format(Dict(video, 'contentDetails', 'videoPublishedAt' )))
-            thumb                           = Dict(video, 'snippet', 'thumbnails', 'standard', 'url') or Dict(video, 'snippet', 'thumbnails', 'high', 'url') or Dict(video, 'snippet', 'thumbnails', 'medium', 'url') or Dict(video, 'snippet', 'thumbnails', 'default', 'url')
+            thumb                           = Dict(video, 'snippet', 'thumbnails', 'maxres', 'url') or Dict(video, 'snippet', 'thumbnails', 'medium', 'url')or Dict(video, 'snippet', 'thumbnails', 'standard', 'url') or Dict(video, 'snippet', 'thumbnails', 'high', 'url') or Dict(video, 'snippet', 'thumbnails', 'default', 'url')
             if thumb and thumb not in episode.thumbs:  episode.thumbs[thumb] = Proxy.Media(HTTP.Request(thumb).content, sort_order=1);                                Log.Info('[ ] thumbnail:    {}'.format(thumb))
             Log.Info(u'[ ] channelTitle: {}'.format(Dict(video, 'snippet', 'channelTitle')))
             break
@@ -484,7 +484,7 @@ def Update(metadata, media, lang, force, movie):
               except Exception as e:  Log('Error: "{}"'.format(e))
               else:
                 Log.Info('[?] link:     "https://www.youtube.com/watch?v={}"'.format(videoId))
-                thumb                           = Dict(json_video_details, 'snippet', 'thumbnails', 'standard', 'url') or Dict(json_video_details, 'snippet', 'thumbnails', 'high', 'url') or Dict(json_video_details, 'snippet', 'thumbnails', 'medium', 'url') or Dict(json_video_details, 'snippet', 'thumbnails', 'default', 'url')
+                thumb                           = Dict(json_video_details, 'snippet', 'thumbnails', 'maxres', 'url') or Dict(json_video_details, 'snippet', 'thumbnails', 'medium', 'url') or Dict(json_video_details, 'snippet', 'thumbnails', 'standard', 'url') or Dict(json_video_details, 'snippet', 'thumbnails', 'high', 'url') or Dict(json_video_details, 'snippet', 'thumbnails', 'default', 'url')
                 episode.title                   = sanitize_path(json_video_details['snippet']['title']);                                 Log.Info('[ ] title:    "{}"'.format(json_video_details['snippet']['title']))
                 episode.summary                 = sanitize_path(json_video_details['snippet']['description']);                           Log.Info('[ ] summary:  "{}"'.format(json_video_details['snippet']['description'].replace('\n', '. ')))
                 if len(e)>3:  episode.originally_available_at = Datetime.ParseDate(json_video_details['snippet']['publishedAt']).date();                       Log.Info('[ ] date:     "{}"'.format(json_video_details['snippet']['publishedAt']))


### PR DESCRIPTION
Quick fix that I added to my fork, you are welcome to merge if you want.

I noticed that the preferred video thumbnail size is 4:3. In the Plex web app and the Roku app, the thumbnail is appropriately repositioned so that the letterbox is not seen. But I've recently noticed on the Plex Android TV and Android mobile app, the thumbnail is not centered, so the black bar is seen at the top. (See screenshots below.)

I propose to prefer thumbnails in the following order which prioritizes 16:9.

`maxres` - 1280/720 - 16:9 - [example](https://i.ytimg.com/vi/byva0hOj8CU/maxresdefault.jpg)
`medium` - 320/180 - 16:9 - [example](https://i.ytimg.com/vi/byva0hOj8CU/mqdefault.jpg)
`standard` - 640/480 - 4:3 - [example](https://i.ytimg.com/vi/byva0hOj8CU/sddefault.jpg)
`high` - 480/360 - 4:3 - [example](https://i.ytimg.com/vi/byva0hOj8CU/hqdefault.jpg)
`default` - 120/90 - 4:3 - [example](https://i.ytimg.com/vi/byva0hOj8CU/default.jpg)

BTW, this is basically the same fix as #81.

---

Before fix
 * [Roku app](https://user-images.githubusercontent.com/7417301/119282776-e56fc600-bc08-11eb-9cec-e6a0b8aa195c.jpg)
 * [Web app](https://user-images.githubusercontent.com/7417301/119282819-0fc18380-bc09-11eb-9273-0883d5482956.png)
 * [Android TV app](https://user-images.githubusercontent.com/7417301/119282756-d38e2300-bc08-11eb-9eaf-a6386d3dca95.jpg)
 * [Android app](https://user-images.githubusercontent.com/7417301/119282788-f1f41e80-bc08-11eb-90bb-4a16df095909.jpg)

After fix
 * [Android TV app](https://user-images.githubusercontent.com/7417301/119282844-1d770900-bc09-11eb-8f4d-731d46fa22e7.jpg)
 * [Android app](https://user-images.githubusercontent.com/7417301/119282859-2667da80-bc09-11eb-9a8f-ab93fb73e927.jpg)
