### PR TITLE
Handle no dislike count in video data

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -204,7 +204,7 @@ def Update(metadata, media, lang, force, movie):
           Log(u'poster: "{}" added'.format(thumb))
           metadata.posters[thumb]        = Proxy.Media(HTTP.Request(Dict(json_video_details, 'thumbnails', '0', 'url')).content, sort_order=1)
         else:  Log(u'thumb: "{}" already present'.format(thumb))
-        if Dict(json_video_details, 'statistics', 'likeCount') and int(Dict(json_video_details, 'like_count')) > 0:
+        if Dict(json_video_details, 'statistics', 'likeCount') and int(Dict(json_video_details, 'like_count')) > 0 and Dict(json_video_details, 'dislike_count') and int(Dict(json_video_details, 'dislike_count')) > 0:
           metadata.rating                = float(10*int(Dict(json_video_details, 'like_count'))/(int(Dict(json_video_details, 'dislike_count'))+int(Dict(json_video_details, 'like_count'))));  Log(u'rating: {}'.format(metadata.rating))
         if Prefs['add_user_as_director']:
           metadata.directors.clear()
@@ -232,7 +232,7 @@ def Update(metadata, media, lang, force, movie):
       if thumb and thumb not in metadata.posters:
         Log(u'poster: "{}"'.format(thumb))
         metadata.posters[thumb]        = Proxy.Media(HTTP.Request(Dict(json_video_details, 'snippet', 'thumbnails', 'maxres', 'url') or Dict(json_video_details, 'snippet', 'thumbnails', 'medium', 'url') or Dict(json_video_details, 'snippet', 'thumbnails', 'standard', 'url') or Dict(json_video_details, 'snippet', 'thumbnails', 'high', 'url') or Dict(json_video_details, 'snippet', 'thumbnails', 'default', 'url')).content, sort_order=1)
-      if Dict(json_video_details, 'statistics', 'likeCount') and int(json_video_details['statistics']['likeCount']) > 0:
+      if Dict(json_video_details, 'statistics', 'likeCount') and int(json_video_details['statistics']['likeCount']) > 0 and Dict(json_video_details, 'statistics', 'dislikeCount') and int(Dict(json_video_details, 'statistics', 'dislikeCount')) > 0:
         metadata.rating                = float(10*int(json_video_details['statistics']['likeCount'])/(int(json_video_details['statistics']['dislikeCount'])+int(json_video_details['statistics']['likeCount'])));  Log('rating: {}'.format(metadata.rating))
       if Prefs['add_user_as_director']:
         metadata.directors.clear()
@@ -459,7 +459,7 @@ def Update(metadata, media, lang, force, movie):
                 episode.summary                 = sanitize_path(Dict(json_video_details, 'description'));      Log.Info(u'[ ] summary:  "{}"'.format(Dict(json_video_details, 'description').replace('\n', '. ')))
                 if len(e)>3: episode.originally_available_at = Datetime.ParseDate(Dict(json_video_details, 'upload_date')).date();  Log.Info(u'[ ] date:     "{}"'.format(Dict(json_video_details, 'upload_date')))
                 episode.duration                = int(Dict(json_video_details, 'duration'));                           Log.Info(u'[ ] duration: "{}"'.format(episode.duration))
-                if Dict(json_video_details, 'likeCount') and int(Dict(json_video_details, 'like_count')) > 0:
+                if Dict(json_video_details, 'likeCount') and int(Dict(json_video_details, 'like_count')) > 0 and Dict(json_video_details, 'dislike_count') and int(Dict(json_video_details, 'dislike_count')) > 0:
                   episode.rating                = float(10*int(Dict(json_video_details, 'like_count'))/(int(Dict(json_video_details, 'dislike_count'))+int(Dict(json_video_details, 'like_count'))));  Log('[ ] rating:   "{}"'.format(episode.rating))
                 if channel_title and channel_title not in [role_obj.name for role_obj in episode.directors]:
                   meta_director      = episode.directors.new()
@@ -489,7 +489,7 @@ def Update(metadata, media, lang, force, movie):
                 episode.summary                 = sanitize_path(json_video_details['snippet']['description']);                           Log.Info('[ ] summary:  "{}"'.format(json_video_details['snippet']['description'].replace('\n', '. ')))
                 if len(e)>3:  episode.originally_available_at = Datetime.ParseDate(json_video_details['snippet']['publishedAt']).date();                       Log.Info('[ ] date:     "{}"'.format(json_video_details['snippet']['publishedAt']))
                 episode.duration                = ISO8601DurationToSeconds(json_video_details['contentDetails']['duration'])*1000;               Log.Info('[ ] duration: "{}"->"{}"'.format(json_video_details['contentDetails']['duration'], episode.duration))
-                if Dict(json_video_details, 'statistics', 'likeCount') and int(json_video_details['statistics']['likeCount']) > 0:
+                if Dict(json_video_details, 'statistics', 'likeCount') and int(json_video_details['statistics']['likeCount']) > 0 and Dict(json_video_details, 'statistics', 'dislikeCount') and int(Dict(json_video_details, 'statistics', 'dislikeCount')) > 0:
                   episode.rating                = 10*float(json_video_details['statistics']['likeCount'])/(float(json_video_details['statistics']['dislikeCount'])+float(json_video_details['statistics']['likeCount']));  Log('[ ] rating:   "{}"'.format(episode.rating))
                 if thumb and thumb not in episode.thumbs:
                   picture = HTTP.Request(thumb).content


### PR DESCRIPTION
As announced [here](https://support.google.com/youtube/thread/134791097/update-to-youtube-dislike-counts?hl=en), YouTube video dislikes will be removed from API responses started 13 Dec. Sure enough, today I started noticing failures in YouTube-Agent due to this change.

```
2021-12-14 12:43:17,798 (14ff9da3fb38) :  CRITICAL (agentkit:1095) - Exception in the update function of agent named 'YouTubeSeries', called with guid 'com.plexapp.agents.youtube://youtube|[REDACTED]?lang=xn' (most recent call last):
  File "/usr/lib/plexmediaserver/Resources/Plug-ins-c43dc0277/Framework.bundle/Contents/Resources/Versions/2/Python/Framework/api/agentkit.py", line 1093, in _update
    agent.update(obj, media, lang, **kwargs)
  File "/config/Library/Application Support/Plex Media Server/Plug-ins/YouTube-Agent.bundle/Contents/Code/__init__.py", line 556, in update
    def update (self, metadata, media, lang, force ):  Update (metadata, media, lang, force,  False)
  File "/config/Library/Application Support/Plex Media Server/Plug-ins/YouTube-Agent.bundle/Contents/Code/__init__.py", line 531, in Update
    episode.rating                = 10*float(json_video_details['statistics']['likeCount'])/(float(json_video_details['statistics']['dislikeCount'])+float(json_video_details['statistics']['likeCount']));  Log('[ ] rating:   "{}"'.format(episode.rating))
  File "/usr/lib/plexmediaserver/Resources/Plug-ins-c43dc0277/Framework.bundle/Contents/Resources/Versions/2/Python/Framework/code/sandbox.py", line 108, in <lambda>
    _getitem_           = lambda x, y: x.__getitem__(y),
KeyError: 'dislikeCount'
```

This PR attempts to handle the cases where the dislike count is no longer available.