### PR TITLE
Fixed missing Director

### DIFF
--- a/Contents/Code/__init__.py
+++ b/Contents/Code/__init__.py
@@ -244,9 +244,10 @@ def Update(metadata, media, lang, force, movie):
         if Prefs['add_user_as_director']:
           metadata.directors.clear()
           try:
+            director            = Dict(json_video_details, 'uploader');
             meta_director       = metadata.directors.new()
-            meta_director.name  = channel_title
-            Log('director: '+ channel_title)
+            meta_director.name  = director
+            Log('director: '+ director)
           except:  pass
         return
 


### PR DESCRIPTION
When the Setting "Set YouTube usernames as director in metadata" is enabled and the file `info.json` file is available then the director should be set to the `channel_title`. This results in the director being empty because the `channel_title` is never set (except initially with an empty string).

I added that the director is being filled from the uploader element from the info.json.

This would address #111